### PR TITLE
Fix go vet issues

### DIFF
--- a/chrome.go
+++ b/chrome.go
@@ -172,7 +172,7 @@ type targetMessage struct {
 		ID      int    `json:"executionContextId"`
 		Args    []struct {
 			Type  string      `json:"type"`
-			Value interface{} `json:'value"`
+			Value interface{} `json:"value"`
 		} `json:"args"`
 	} `json:"params"`
 	Error struct {


### PR DESCRIPTION
go vet is returning an error inside this file:
```
Line 175: error: struct field tag `json:'value"` not compatible with reflect.StructTag.Get: bad syntax for struct tag value (vet)
```