### PR TITLE
fix Chrome open download URL feature for Windows and MacOS

### DIFF
--- a/locate.go
+++ b/locate.go
@@ -50,9 +50,9 @@ func PromptDownload() {
 	switch runtime.GOOS {
 	case "linux":
 		exec.Command("xdg-open", url).Run()
-	case "windows":
-		exec.Command("open", url).Run()
 	case "darwin":
+		exec.Command("open", url).Run()
+	case "windows":
 		r := strings.NewReplacer("&", "^&")
 		exec.Command("cmd", "/c", "start", r.Replace(url)).Run()
 	}


### PR DESCRIPTION
Minor fix to switch `windows` and `darwin` in switch statement when opening Chrome download URL.