### PR TITLE
make Eval script work after reload

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -163,6 +163,7 @@ func (u *ui) Bind(name string, f interface{}) error {
 }
 
 func (u *ui) Eval(js string) Value {
+	u.chrome.send("Page.addScriptToEvaluateOnNewDocument", h{"source": js})
 	v, err := u.chrome.eval(js)
 	return value{err: err, raw: v}
 }

--- a/ui.go
+++ b/ui.go
@@ -163,7 +163,10 @@ func (u *ui) Bind(name string, f interface{}) error {
 }
 
 func (u *ui) Eval(js string) Value {
-	u.chrome.send("Page.addScriptToEvaluateOnNewDocument", h{"source": js})
+	_, err := u.chrome.send("Page.addScriptToEvaluateOnNewDocument", h{"source": js})
+	if err != nil {
+		return value{err: err, raw: nil}
+	}
 	v, err := u.chrome.eval(js)
 	return value{err: err, raw: v}
 }


### PR DESCRIPTION
Currently `Eval` would not survive after a reload. I add `Page.addScriptToEvaluateOnNewDocument` in ui.Eval to make sure Eval script can run after reload.

I think extra document will be needed since script will be run before document ready, so user should wrap their own code inside a `DOMContentLoaded`