### PR TITLE
Add support for 32 bit windows

### DIFF
--- a/locate.go
+++ b/locate.go
@@ -24,6 +24,7 @@ func LocateChrome() string {
 		"/Applications/Chromium.app/Contents/MacOS/Chromium",
 		"C:/Users/" + os.Getenv("USERNAME") + "/AppData/Local/Google/Chrome/Application/chrome.exe",
 		"C:/Program Files (x86)/Google/Chrome/Application/chrome.exe",
+		"C:/Program Files/Google/Chrome/Application/chrome.exe",
 	}
 
 	for _, path := range paths {


### PR DESCRIPTION
There is no `Program Files (x86)` on 32 bit windows😥. Had to make the change to get it to work on my intel compute stick.