### PR TITLE
ignore chrome.kill error

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -94,9 +94,8 @@ func (u *ui) Done() <-chan struct{} {
 }
 
 func (u *ui) Close() error {
-	if err := u.chrome.kill(); err != nil {
-		return err
-	}
+	// ignore err, as the chrome process might be already dead, when user close the window.
+	u.chrome.kill()
 	<-u.done
 	if u.tmpDir != "" {
 		if err := os.RemoveAll(u.tmpDir); err != nil {


### PR DESCRIPTION
The chrome process could be killed already when user closes the window. We should ignore the error and continue to clean up the tmpDir.