### PR TITLE
Fix panic when the only result is a nil error

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -139,7 +139,10 @@ func (u *ui) Bind(name string, f interface{}) error {
 		case 1:
 			// One result may be a value, or an error
 			if res[0].Type().Implements(errorType) {
-				return nil, res[0].Interface().(error)
+				if res[0].Interface() != nil {
+					return nil, res[0].Interface().(error)
+				}
+				return nil, nil
 			}
 			return res[0].Interface(), nil
 		case 2:


### PR DESCRIPTION
This fixes the panic that happens when a bound function having only one error-like return value returns `nil`.

An example of the issue is the following

```go
package main

import (
	"github.com/zserge/lorca"
)

func oneNilErrorResult() error {
	return nil
}

func main() {
	ui, _ := lorca.New("", "", 480, 320)
	defer ui.Close()

	ui.Bind("oneNilErrorResult", oneNilErrorResult)

	ui.Eval("oneNilErrorResult()") // Panic!

	<-ui.Done()
}
```

which causes the following error

```
panic: interface conversion: interface is nil, not error

goroutine 23 [running]:
github.com/zserge/lorca.(*ui).Bind.func1(0xa59470, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
        github.com/zserge/lorca@v0.1.7/ui.go:142 +0x711
github.com/zserge/lorca.(*chrome).readLoop.func2(0xc000158900, 0xc0001caf90, 0x7a2430, 0xc0000e40c0, 0xc0001c2b40)
        github.com/zserge/lorca@v0.1.7/chrome.go:289 +0x65
created by github.com/zserge/lorca.(*chrome).readLoop
        github.com/zserge/lorca@v0.1.7/chrome.go:287 +0x95e
exit status 2
```