### PR TITLE
Add possibility to overwrite an already existing binding.

### DIFF
--- a/chrome.go
+++ b/chrome.go
@@ -376,8 +376,18 @@ func (c *chrome) eval(expr string) (json.RawMessage, error) {
 
 func (c *chrome) bind(name string, f bindingFunc) error {
 	c.Lock()
+	// check if binding already exists
+	_, exists := c.bindings[name]
+
 	c.bindings[name] = f
 	c.Unlock()
+
+	if exists {
+		// Just replace callback and return, as the binding was already added to js
+		// and adding it again would break it.
+		return nil
+	}
+
 	if _, err := c.send("Runtime.addBinding", h{"name": name}); err != nil {
 		return err
 	}


### PR DESCRIPTION
Add possibility to overwrite an already existing binding.

I have the case that my application has different modules and I can load and unload each module. On each load the bindings may change to a different struct-reference and therefore I add these bindings again. But this produced a wired error because the binding-js is added again to the page.

Now I just add the js once and only change the callback if there was already one.