### PR TITLE
Add location for snap version of Chromium

### DIFF
--- a/locate.go
+++ b/locate.go
@@ -39,6 +39,7 @@ func LocateChrome() string {
 			"/usr/bin/google-chrome",
 			"/usr/bin/chromium",
 			"/usr/bin/chromium-browser",
+			"/snap/bin/chromium",
 		}
 	}
 


### PR DESCRIPTION
This adds another location in which Chromium can be found on Ubuntu.

Fixes #61