### PR TITLE
Use %LocalAppData% and %ProgramFiles% to locate Chrome on Windows.

### DIFF
--- a/locate.go
+++ b/locate.go
@@ -28,10 +28,12 @@ func LocateChrome() string {
 		}
 	case "windows":
 		paths = []string{
-			"C:/Users/" + os.Getenv("USERNAME") + "/AppData/Local/Google/Chrome/Application/chrome.exe",
-			"C:/Program Files (x86)/Google/Chrome/Application/chrome.exe",
-			"C:/Program Files/Google/Chrome/Application/chrome.exe",
-			"C:/Users/" + os.Getenv("USERNAME") + "/AppData/Local/Chromium/Application/chrome.exe",
+			os.Getenv("LocalAppData") + "/Google/Chrome/Application/chrome.exe",
+			os.Getenv("ProgramFiles") + "/Google/Chrome/Application/chrome.exe",
+			os.Getenv("ProgramFiles(x86)") + "/Google/Chrome/Application/chrome.exe",
+			os.Getenv("LocalAppData") + "/Chromium/Application/chrome.exe",
+			os.Getenv("ProgramFiles") + "/Chromium/Application/chrome.exe",
+			os.Getenv("ProgramFiles(x86)") + "/Chromium/Application/chrome.exe",
 		}
 	default:
 		paths = []string{


### PR DESCRIPTION
Because the system drive of a Windows PC may not be `C:`.