### PR TITLE
Use native window titlebar on Windows 10 to make a lorca app look closer to a native app

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -44,6 +44,7 @@ var defaultChromeArgs = []string{
 	"--disable-renderer-backgrounding",
 	"--disable-sync",
 	"--disable-translate",
+	"--disable-windows10-custom-titlebar",
 	"--metrics-recording-only",
 	"--no-first-run",
 	"--safebrowsing-disable-auto-update",


### PR DESCRIPTION
**Before:**

![Before](https://user-images.githubusercontent.com/30952626/73555944-76a5b100-4489-11ea-9506-386fa38b95e2.png)

**After:**

![After](https://user-images.githubusercontent.com/30952626/73556429-65a96f80-448a-11ea-8179-09794885c450.png)
