### PR TITLE
Fix undefined variable FS with proper path

### DIFF
--- a/examples/counter/main.go
+++ b/examples/counter/main.go
@@ -65,7 +65,7 @@ func main() {
 		log.Fatal(err)
 	}
 	defer ln.Close()
-	go http.Serve(ln, http.FileServer(FS))
+	go http.Serve(ln, http.FileServer(http.Dir("./www")))
 	ui.Load(fmt.Sprintf("http://%s", ln.Addr()))
 
 	// You may use console.log to debug your JS code, it will be printed via


### PR DESCRIPTION
Fixes #105 by accessing the correct folder.  Will only work with `go run`