### PR TITLE
feat: added RawValue interface

### DIFF
--- a/value.go
+++ b/value.go
@@ -15,12 +15,18 @@ type Value interface {
 	Array() []Value
 }
 
+// RawValue is a raw JSON value.
+type RawValue interface {
+	Bytes() []byte
+}
+
 type value struct {
 	err error
 	raw json.RawMessage
 }
 
 func (v value) Err() error             { return v.err }
+func (v value) Bytes() []byte          { return v.raw }
 func (v value) To(x interface{}) error { return json.Unmarshal(v.raw, x) }
 func (v value) Float() (f float32)     { v.To(&f); return f }
 func (v value) Int() (i int)           { v.To(&i); return i }

--- a/value.go
+++ b/value.go
@@ -13,10 +13,6 @@ type Value interface {
 	Bool() bool
 	Object() map[string]Value
 	Array() []Value
-}
-
-// RawValue is a raw JSON value.
-type RawValue interface {
 	Bytes() []byte
 }
 

--- a/value_test.go
+++ b/value_test.go
@@ -3,6 +3,7 @@ package lorca
 import (
 	"encoding/json"
 	"errors"
+	"reflect"
 	"testing"
 )
 
@@ -47,6 +48,28 @@ func TestValueComplex(t *testing.T) {
 		t.Fail()
 	}
 	if v.Array()[2].Object()["x"].Int() != 5 {
+		t.Fail()
+	}
+}
+
+func TestRawValue(t *testing.T) {
+	var v Value
+
+	v = value{raw: json.RawMessage(nil)}
+	r, ok := v.(RawValue)
+	if !ok {
+		t.Fail()
+	}
+	if r.Bytes() != nil {
+		t.Fail()
+	}
+
+	v = value{raw: json.RawMessage(`"hello"`)}
+	r, ok = v.(RawValue)
+	if !ok {
+		t.Fail()
+	}
+	if !reflect.DeepEqual(r.Bytes(), []byte(`"hello"`)) {
 		t.Fail()
 	}
 }

--- a/value_test.go
+++ b/value_test.go
@@ -56,20 +56,12 @@ func TestRawValue(t *testing.T) {
 	var v Value
 
 	v = value{raw: json.RawMessage(nil)}
-	r, ok := v.(RawValue)
-	if !ok {
-		t.Fail()
-	}
-	if r.Bytes() != nil {
+	if v.Bytes() != nil {
 		t.Fail()
 	}
 
 	v = value{raw: json.RawMessage(`"hello"`)}
-	r, ok = v.(RawValue)
-	if !ok {
-		t.Fail()
-	}
-	if !reflect.DeepEqual(r.Bytes(), []byte(`"hello"`)) {
+	if !reflect.DeepEqual(v.Bytes(), []byte(`"hello"`)) {
 		t.Fail()
 	}
 }

--- a/value_test.go
+++ b/value_test.go
@@ -1,9 +1,9 @@
 package lorca
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
-	"reflect"
 	"testing"
 )
 
@@ -61,7 +61,7 @@ func TestRawValue(t *testing.T) {
 	}
 
 	v = value{raw: json.RawMessage(`"hello"`)}
-	if !reflect.DeepEqual(v.Bytes(), []byte(`"hello"`)) {
+	if !bytes.Equal(v.Bytes(), []byte(`"hello"`)) {
 		t.Fail()
 	}
 }


### PR DESCRIPTION
To allow for the detection of a `nil` return, a new interface is added (to maintain backwards compatibility) and implemented by `value`. This interface, `RawValue`, allows the retrieval of the raw bytes but requires a type assertion.

Fixes #126 