### PR TITLE
Support for Edge Chromium

### DIFF
--- a/locate.go
+++ b/locate.go
@@ -42,6 +42,7 @@ func LocateChrome() string {
 			os.Getenv("LocalAppData") + "/Chromium/Application/chrome.exe",
 			os.Getenv("ProgramFiles") + "/Chromium/Application/chrome.exe",
 			os.Getenv("ProgramFiles(x86)") + "/Chromium/Application/chrome.exe",
+			os.Getenv("ProgramFiles(x86)") + "/Microsoft/Edge/Application/msedge.exe",
 		}
 	default:
 		paths = []string{


### PR DESCRIPTION
Adds MSEdge to LocateChrome() for windows. This will use Chromium Edge if Chrome is not installed.