### PR TITLE
can exclude some args from defaultChromeArgs

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -56,11 +56,12 @@ var defaultChromeArgs = []string{
 
 // New returns a new HTML5 UI for the given URL, user profile directory, window
 // size and other options passed to the browser engine. If URL is an empty
+// excludeDefaultArgs, if you don not want to use some default Chrome args, you can add them by slice
 // string - a blank page is displayed. If user profile directory is an empty
 // string - a temporary directory is created and it will be removed on
 // ui.Close(). You might want to use "--headless" custom CLI argument to test
 // your UI code.
-func New(url, dir string, width, height int, customArgs ...string) (UI, error) {
+func New(url, dir string, width, height int, excludeDefaultArgs []string, customArgs ...string) (UI, error) {
 	if url == "" {
 		url = "data:text/html,<html></html>"
 	}
@@ -72,7 +73,8 @@ func New(url, dir string, width, height int, customArgs ...string) (UI, error) {
 		}
 		dir, tmpDir = name, name
 	}
-	args := append(defaultChromeArgs, fmt.Sprintf("--app=%s", url))
+	finallyChromeArgs := mergeArgs(defaultChromeArgs, excludeDefaultArgs)
+	args := append(finallyChromeArgs, fmt.Sprintf("--app=%s", url))
 	args = append(args, fmt.Sprintf("--user-data-dir=%s", dir))
 	args = append(args, fmt.Sprintf("--window-size=%d,%d", width, height))
 	args = append(args, customArgs...)
@@ -173,4 +175,23 @@ func (u *ui) SetBounds(b Bounds) error {
 
 func (u *ui) Bounds() (Bounds, error) {
 	return u.chrome.bounds()
+}
+
+func mergeArgs(defaultArgs []string, excludeArgs []string) []string {
+	result := []string{}
+	for _, arg := range defaultArgs {
+		if !has(excludeArgs, arg) {
+			result = append(result, arg)
+		}
+	}
+	return result
+}
+
+func has(source []string, target string) bool {
+	for _, s := range source {
+		if s == target {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
#167 
I added a new argument(excludeDefaultArgs) to the New method, which allows excluding specific arguments from the predefined defaultChromeArgs. This is to address the issue of Chrome causing redundant content when using the enable-automation input parameter after deprecating --disable-infobars. Developers can add --enable-automation into this new argument to exclude it.