### PR TITLE
Overwrite default_args with costome_args

### DIFF
--- a/examples/counter/main.go
+++ b/examples/counter/main.go
@@ -11,7 +11,7 @@ import (
 	"runtime"
 	"sync"
 
-	"github.com/zserge/lorca"
+	"github.com/lishimeng/lorca"
 )
 
 //go:embed www

--- a/examples/hello/main.go
+++ b/examples/hello/main.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"net/url"
 
-	"github.com/zserge/lorca"
+	"github.com/lishimeng/lorca"
 )
 
 func main() {

--- a/examples/stopwatch/main.go
+++ b/examples/stopwatch/main.go
@@ -7,7 +7,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/zserge/lorca"
+	"github.com/lishimeng/lorca"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/zserge/lorca
+module github.com/lishimeng/lorca
 
 go 1.16
 

--- a/ui.go
+++ b/ui.go
@@ -79,6 +79,8 @@ func New(url, dir string, width, height int, customArgs ...string) (UI, error) {
 	args = append(args, customArgs...)
 	args = append(args, "--remote-debugging-port=0")
 
+	args = handleArgs(args)
+
 	chrome, err := newChromeWithArgs(ChromeExecutable(), args...)
 	done := make(chan struct{})
 	if err != nil {
@@ -90,6 +92,17 @@ func New(url, dir string, width, height int, customArgs ...string) (UI, error) {
 		close(done)
 	}()
 	return &ui{chrome: chrome, done: done, tmpDir: tmpDir}, nil
+}
+
+func handleArgs(src []string) (dest []string) {
+	m := make(map[string]bool)
+	for _, s := range src {
+		m[s] = true
+	}
+	for s, _ := range m {
+		dest = append(dest, s)
+	}
+	return
 }
 
 func (u *ui) Done() <-chan struct{} {


### PR DESCRIPTION
func New(url, dir string, width, height int, customArgs ...string) (UI, error) {
	...
	args := append(defaultChromeArgs, fmt.Sprintf("--app=%s", url))
	args = append(args, fmt.Sprintf("--user-data-dir=%s", dir))
	args = append(args, fmt.Sprintf("--window-size=%d,%d", width, height))
	args = append(args, **customArgs**...)
	args = append(args, "--remote-debugging-port=0")

	**args = handleArgs(args) // override default args with custome args** 

	chrome, err := newChromeWithArgs(ChromeExecutable(), args...)
	...
}

func handleArgs(src []string) (dest []string) {
	m := make(map[string]bool)
	for _, s := range src {
		m[s] = true
	}
	for s, _ := range m {
		dest = append(dest, s)
	}
	return
}